### PR TITLE
Changed Example 5 in mech examples

### DIFF
--- a/00_SourceCode/@OrigamiSolver/Solver_Solve.m
+++ b/00_SourceCode/@OrigamiSolver/Solver_Solve.m
@@ -1,4 +1,4 @@
-% This function runs the analyses. 
+% This function runs the analyses.
 % for some of the analyses, future updates are needed so that code can run.
 
 function Solver_Solve(obj)
@@ -7,23 +7,23 @@ function Solver_Solve(obj)
     % automatically initialize the status;
     if obj.continuingLoading==0
         % Initialze the origami structure first
-        
+
         % We assume that the initial deformation field is zero and that the
         % origami has no load applied.
         newNodeNum = size(obj.newNode);
         newNodeNum = newNodeNum(1);
-        obj.currentU = zeros(newNodeNum,3);    
+        obj.currentU = zeros(newNodeNum,3);
         obj.currentAppliedForce = zeros(newNodeNum,3);
-        
+
         % Then calculate the origami mechanical proeprties
         % We first calcualte the folding angle, assume that the current
-        % state is stress free. 
-        
+        % state is stress free.
+
         if obj.mesh2D3D==2
             obj.currentRotZeroStrain=pi*ones(obj.oldCreaseNum,1);
             obj.currentSprZeroStrain=obj.Spr_Theta(...
                 obj.currentU,obj.sprIJKL,obj.newNode);
-        else  
+        else
             if obj.compliantCreaseOpen==1
 
                 obj.compliantCreaseOpen=0;
@@ -35,16 +35,16 @@ function Solver_Solve(obj)
 
                 for i = 1:obj.oldCreaseNum
                     if obj.currentSprZeroStrain(i,1) ~=0
-                        obj.currentRotZeroStrain(i)=obj.currentSprZeroStrain(i,1);    
+                        obj.currentRotZeroStrain(i)=obj.currentSprZeroStrain(i,1);
                     end
                 end
-                
+
             % Here we mesh the system with no compliant crease, calculate the
             % rotaiton angle for spring elements and then record the numbers as
             % the rotation angle for Rot.
-            
+
                 obj.compliantCreaseOpen=1;
-                obj.Mesh_Mesh();    
+                obj.Mesh_Mesh();
 
             else
                 obj.currentRotZeroStrain=pi*ones(obj.oldCreaseNum,1);
@@ -57,9 +57,9 @@ function Solver_Solve(obj)
                     end
                 end
             end
-        
+
         end
-        
+
         obj.Mesh_MechanicalProperty()
         obj.currentSprZeroStrain=obj.Spr_Theta(...
                 obj.currentU,obj.sprIJKL,obj.newNode);
@@ -68,121 +68,121 @@ function Solver_Solve(obj)
         % system has zero heating input and every node at RT
         obj.currentT=obj.RT*ones(newNodeNum,1);
         obj.currentQ=zeros(obj.envLayer*newNodeNum,1);
-        
+
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     % Just a note here. The current initialization code is not so
-    % perfect. The stress free RotVector can have a small divergence from 
-    % what we get from the real folding from the meshing code. This needs 
-    % to be fixed in the future.         
+    % perfect. The stress free RotVector can have a small divergence from
+    % what we get from the real folding from the meshing code. This needs
+    % to be fixed in the future.
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-    
+
     end
-    
+
     % We sequentially reads the items in the loading controller and
-    % perform the analysis. The loading history is recorded. 
+    % perform the analysis. The loading history is recorded.
     totalLoadSsequance = size(obj.loadingController);
     totalLoadSsequance = totalLoadSsequance(1,2);
-    
+
     for loadSequeceNum=1:totalLoadSsequance
-        
-        % get the temp loading Controller 
+
+        % get the temp loading Controller
         tempController=obj.loadingController{loadSequeceNum};
         analyzeType=tempController{1};
-        tempController=tempController{2};  
-        
-        if analyzeType=="DC"            
+        tempController=tempController{2};
+
+        if strcmp(analyzeType,"DC")
             % perform the displacement controlled loading
             [U,UhisLoading,loadHis,strainEnergyLoading,...
                 nodeForce,loadForce,contactForce]=...
-                obj.Solver_LoadingDC(tempController); 
+                obj.Solver_LoadingDC(tempController);
             % plot the reults when ploting option is open
             if tempController.plotOpen==1
-                obj.Plot_DeformedShape(obj.currentU+obj.newNode, U+obj.newNode);                
+                obj.Plot_DeformedShape(obj.currentU+obj.newNode, U+obj.newNode);
             end
             if tempController.videoOpen==1
-                obj.Plot_DeformedHis(obj.newNode,UhisLoading); 
+                obj.Plot_DeformedHis(obj.newNode,UhisLoading);
             end
-            if tempController.detailFigOpen==1                
+            if tempController.detailFigOpen==1
                 obj.Plot_LoadHis(loadHis,UhisLoading)
                 obj.Plot_Energy(UhisLoading,strainEnergyLoading);
                 obj.Plot_LoadAndReaction(obj.currentU+obj.newNode, ...
                     U+obj.newNode, tempController.load, ...
-                    tempController.supp, nodeForce, loadForce);                
+                    tempController.supp, nodeForce, loadForce);
                 if obj.contactOpen==1
                     obj.Plot_ContactForce(obj.currentU+obj.newNode,...
                     U+obj.newNode,contactForce);
                 end
-            end             
+            end
             % update the current status or origami after loading
-            obj.currentAppliedForce=loadForce+obj.currentAppliedForce;  
+            obj.currentAppliedForce=loadForce+obj.currentAppliedForce;
             obj.currentU=U;
-            
+
             tempController.Uhis=UhisLoading;
             tempController.loadHis=loadHis;
             tempController.strainEnergyHis=strainEnergyLoading;
-            
-        elseif analyzeType=="NR"
+
+        elseif strcmp(analyzeType,"NR")
             %perform the displacement controlled loading
             [U,UhisLoading,loadHis,strainEnergyLoading,...
                 nodeForce,loadForce,contactForce]=...
                 obj.Solver_LoadingNR(tempController);
                         % plot the reults when ploting option is open
             if tempController.plotOpen==1
-                obj.Plot_DeformedShape(obj.currentU+obj.newNode, U+obj.newNode);                
+                obj.Plot_DeformedShape(obj.currentU+obj.newNode, U+obj.newNode);
             end
             if tempController.videoOpen==1
-                obj.Plot_DeformedHis(obj.newNode,UhisLoading); 
+                obj.Plot_DeformedHis(obj.newNode,UhisLoading);
             end
-            if tempController.detailFigOpen==1                
+            if tempController.detailFigOpen==1
                 obj.Plot_LoadHis(loadHis,UhisLoading)
                 obj.Plot_Energy(UhisLoading,strainEnergyLoading);
                 obj.Plot_LoadAndReaction(obj.currentU+obj.newNode, ...
                     U+obj.newNode, tempController.load, ...
-                    tempController.supp, nodeForce, loadForce);                
+                    tempController.supp, nodeForce, loadForce);
                 if obj.contactOpen==1
                     obj.Plot_ContactForce(obj.currentU+obj.newNode,...
                     U+obj.newNode,contactForce);
                 end
-            end             
+            end
             % update the current status or origami after loading
-            obj.currentAppliedForce=loadForce+obj.currentAppliedForce;  
+            obj.currentAppliedForce=loadForce+obj.currentAppliedForce;
             obj.currentU=U;
-            
+
             tempController.Uhis=UhisLoading;
             tempController.loadHis=loadHis;
             tempController.strainEnergyHis=strainEnergyLoading;
-            
-        elseif analyzeType=="MGDCM"
+
+        elseif strcmp(analyzeType,"MGDCM")
             % perform the MGDCM controlled loading
             [U,UhisLoading,loadHis,strainEnergyLoading,...
                 nodeForce,loadForce,contactForce]...
                 =Solver_LoadingMGDCM(obj,tempController);
             if tempController.plotOpen==1
-                obj.Plot_DeformedShape(obj.currentU+obj.newNode, U+obj.newNode);                
+                obj.Plot_DeformedShape(obj.currentU+obj.newNode, U+obj.newNode);
             end
             if tempController.videoOpen==1
-                obj.Plot_DeformedHis(obj.newNode,UhisLoading); 
+                obj.Plot_DeformedHis(obj.newNode,UhisLoading);
             end
-            if tempController.detailFigOpen==1                
+            if tempController.detailFigOpen==1
                 obj.Plot_LoadHis(loadHis,UhisLoading)
                 obj.Plot_Energy(UhisLoading,strainEnergyLoading);
                 obj.Plot_LoadAndReaction(obj.currentU+obj.newNode, ...
                     U+obj.newNode, tempController.load, ...
-                    tempController.supp, nodeForce, loadForce);                
+                    tempController.supp, nodeForce, loadForce);
                 if obj.contactOpen==1
                     obj.Plot_ContactForce(obj.currentU+obj.newNode,...
                     U+obj.newNode,contactForce);
                 end
-            end            
+            end
             % update the current status or origami after loading
-            obj.currentAppliedForce=loadForce+obj.currentAppliedForce;  
+            obj.currentAppliedForce=loadForce+obj.currentAppliedForce;
             obj.currentU=U;
-            
+
             tempController.Uhis=UhisLoading;
             tempController.loadHis=loadHis;
             tempController.strainEnergyHis=strainEnergyLoading;
-            
-        elseif analyzeType=="SelfFold"             
+
+        elseif strcmp(analyzeType,"SelfFold")
             % perform the self folding analysis
             [U,UhisAssemble,strainEnergyAssemble,...
                 sprTargetZeroStrain,rotTargetZeroStrain]=...
@@ -192,27 +192,27 @@ function Solver_Solve(obj)
                 obj.Plot_DeformedShape(obj.currentU+obj.newNode, U+obj.newNode);
             end
             if tempController.videoOpen==1
-                obj.Plot_DeformedHis(obj.newNode,UhisAssemble); 
+                obj.Plot_DeformedHis(obj.newNode,UhisAssemble);
             end
-            if tempController.detailFigOpen==1                
+            if tempController.detailFigOpen==1
                 obj.Plot_Energy(UhisAssemble,strainEnergyAssemble);
             end
             % update the current status or origami after loading
             obj.currentU=U;
             obj.currentRotZeroStrain=rotTargetZeroStrain;
             obj.currentSprZeroStrain=sprTargetZeroStrain;
-            
+
             tempController.Uhis=UhisAssemble;
             tempController.strainEnergyHis=strainEnergyAssemble;
-            
-        elseif analyzeType=="ElectroThermal"
+
+        elseif strcmp(analyzeType,"ElectroThermal")
             beforeLoadingU=obj.currentU;
             obj.Thermal_NewPanel2NewBar();
             % perform the electro-thermal loading analysis
             [U,UhisThermal,energyHisThermal,temperatureHistory,...
                 rotTargetZeroStrain,sprTargetZeroStrain]=...
                 obj.Solver_LoadingElectroThermal(tempController);
-            
+
             % plot the reults when ploting option is open
             if tempController.plotOpen==1
                 obj.Plot_DeformedShapeTemp(tempController,...
@@ -224,9 +224,9 @@ function Solver_Solve(obj)
                loadingHis(p,:,:)= squeeze(loadingHis(p,:,:))- beforeLoadingU;
             end
             if tempController.videoOpen==1
-                obj.Plot_DeformedHisTemp(obj.newNode+beforeLoadingU,loadingHis,temperatureHistory); 
+                obj.Plot_DeformedHisTemp(obj.newNode+beforeLoadingU,loadingHis,temperatureHistory);
             end
-            if tempController.detailFigOpen==1                
+            if tempController.detailFigOpen==1
                 obj.Plot_Energy(UhisAssemble,energyHisThermal);
             end
             % update the current status or origami after loading
@@ -234,19 +234,19 @@ function Solver_Solve(obj)
             obj.currentT=temperatureHistory(:,tempController.thermalStep);
             obj.currentRotZeroStrain=rotTargetZeroStrain;
             obj.currentSprZeroStrain=sprTargetZeroStrain;
-            
+
             tempController.Uhis=UhisThermal;
             tempController.strainEnergyHis=energyHisThermal;
             tempController.temperatureHis=temperatureHistory;
-            
-        elseif analyzeType=="ChangingTemperature"
+
+        elseif strcmp(analyzeType,"ChangingTemperature")
             beforeLoadingU=obj.currentU;
             obj.Thermal_NewPanel2NewBar();
             % loading analysis with changing ambient temperature
             [U,UhisThermal,energyHisThermal,temperatureHistory,...
                 rotTargetZeroStrain,sprTargetZeroStrain]=...
                 obj.Solver_LoadingChangingTemperature(tempController);
-            
+
             % plot the reults when ploting option is open
             if tempController.plotOpen==1
                 obj.Plot_DeformedShapeTemp(tempController,...
@@ -258,9 +258,9 @@ function Solver_Solve(obj)
                loadingHis(p,:,:)= squeeze(loadingHis(p,:,:))- beforeLoadingU;
             end
             if tempController.videoOpen==1
-                obj.Plot_DeformedHisTemp(obj.newNode+beforeLoadingU,loadingHis,temperatureHistory); 
+                obj.Plot_DeformedHisTemp(obj.newNode+beforeLoadingU,loadingHis,temperatureHistory);
             end
-            if tempController.detailFigOpen==1                
+            if tempController.detailFigOpen==1
                 obj.Plot_Energy(UhisAssemble,energyHisThermal);
             end
             % update the current status or origami after loading
@@ -268,16 +268,16 @@ function Solver_Solve(obj)
             obj.currentT=temperatureHistory(:,tempController.thermalStep);
             obj.currentRotZeroStrain=rotTargetZeroStrain;
             obj.currentSprZeroStrain=sprTargetZeroStrain;
-            
+
             tempController.Uhis=UhisThermal;
             tempController.strainEnergyHis=energyHisThermal;
             tempController.temperatureHis=temperatureHistory;
-            
-        elseif analyzeType=="Dynamics"
+
+        elseif strcmp(analyzeType,"Dynamics")
             obj.Thermal_NewPanel2NewBar();
             % loading analysis with changing ambient temperature
             [U,Uhis]=obj.Solver_Dynamics(tempController);
-            
+
             % plot the reults when ploting option is open
             if tempController.plotOpen==1
                 obj.Plot_DeformedShape(obj.currentU+obj.newNode, U+obj.newNode);
@@ -292,9 +292,9 @@ function Solver_Solve(obj)
                 for i=1:totalStep
                     UhisCorp(i,:,:)=Uhis(videoCropRate*i,:,:);
                 end
-                obj.Plot_DeformedHis(obj.newNode,UhisCorp) 
+                obj.Plot_DeformedHis(obj.newNode,UhisCorp)
             end
-            if tempController.detailFigOpen==1                
+            if tempController.detailFigOpen==1
                 obj.Plot_Energy(UhisAssemble,energyHisThermal);
             end
             % update the current status or origami after loading
@@ -303,12 +303,12 @@ function Solver_Solve(obj)
             %obj.currentRotZeroStrain=rotTargetZeroStrain;
             %obj.currentSprZeroStrain=sprTargetZeroStrain;
 
-        elseif analyzeType=="DynamicsThermal"
+        elseif strcmp(analyzeType,"DynamicsThermal")
             obj.Thermal_NewPanel2NewBar();
             % loading analysis with changing ambient temperature
             [U,Uhis,energyHisThermal,temperatureHistory]=...
                 obj.Solver_DynamicsThermal(tempController);
-            
+
             % plot the reults when ploting option is open
             if tempController.plotOpen==1
                 obj.Plot_DeformedShapeTemp(tempController,...
@@ -330,7 +330,7 @@ function Solver_Solve(obj)
                 obj.Plot_DeformedHisTemp(obj.newNode, ...
                     UhisCorp,tempHisCorp);
             end
-            if tempController.detailFigOpen==1                
+            if tempController.detailFigOpen==1
                 obj.Plot_Energy(UhisAssemble,energyHisThermal);
             end
 
@@ -338,8 +338,8 @@ function Solver_Solve(obj)
             obj.currentU=U;
             % obj.currentRotZeroStrain=rotTargetZeroStrain;
             % obj.currentSprZeroStrain=sprTargetZeroStrain;
-            
-            
+
+
         end
     end
 end

--- a/01_Example_Mechanical_Loading/Example05_LockingLinkage.m
+++ b/01_Example_Mechanical_Loading/Example05_LockingLinkage.m
@@ -6,32 +6,32 @@
 % Acknowledgement: We would like to acknowledge the prior works from
 % Ke Liu and Glaucio H. Paulino for establishing shared versions of
 % nonrigid origami simulators. Their works paved the way for the new
-% origami simulator presented in this package. 
+% origami simulator presented in this package.
 %
 % Reference:
-% [1] Yi Zhu, Evgueni T. Filipov (2021). 'Sequentially Working Origami 
+% [1] Yi Zhu, Evgueni T. Filipov (2021). 'Sequentially Working Origami
 %     Multi-Physics Simulator (SWOMPS): A Versatile Implementation',
-%     ASME IDETC-CIE Conference. DETC2021-68042. 
-% [2] Y. Zhu, E. T. Filipov (2021). 'Rapid Multi-Physic Simulation for 
-%     Electro-Thermal Origami Robotic Systems'  International Journal of 
+%     ASME IDETC-CIE Conference. DETC2021-68042.
+% [2] Y. Zhu, E. T. Filipov (2021). 'Rapid Multi-Physic Simulation for
+%     Electro-Thermal Origami Robotic Systems'  International Journal of
 %     Mechanical Sciences, 202-203, 106537.
-% [3] Y. Zhu, E. T. Filipov (2020). 'A Bar and Hinge Model for Simulating 
-%     Bistability in Origami Structures with Compliant Creases' Journal of 
-%     Mechanisms and Robotics, 021110-1. 
-% [4] Y. Zhu, E. T. Filipov (2019). 'An Efficient Numerical Approach for 
-%     Simulating Contact in Origami Assemblages.' Proc. R. Soc. A, 475: 
-%     20190366.       
-% [5] Y. Zhu, E. T. Filipov (2019). 'Simulating compliant crease origami 
-%     with a bar and hinge model.' IDETC/CIE 2019. 97119. 
-% [6] K. Liu, G. H. Paulino (2018). 'Highly efficient nonlinear        
-%     structural analysis of origami assemblages using the MERLIN2      
-%     software.' Origami^7. 
-% [7] K. Liu, G. H. Paulino (2017). 'Nonlinear mechanics of non-rigid   
-%     origami - An efficient computational approach.' Proc. R. Soc. A 473: 
-%     20170348. 
-% [8] K. Liu, G. H. Paulino (2016). 'MERLIN: A MATLAB implementation to   
-%     capture highly nonlinear behavior of non-rigid origami.'           
-%     Proceedings of IASS Annual Symposium 2016. 
+% [3] Y. Zhu, E. T. Filipov (2020). 'A Bar and Hinge Model for Simulating
+%     Bistability in Origami Structures with Compliant Creases' Journal of
+%     Mechanisms and Robotics, 021110-1.
+% [4] Y. Zhu, E. T. Filipov (2019). 'An Efficient Numerical Approach for
+%     Simulating Contact in Origami Assemblages.' Proc. R. Soc. A, 475:
+%     20190366.
+% [5] Y. Zhu, E. T. Filipov (2019). 'Simulating compliant crease origami
+%     with a bar and hinge model.' IDETC/CIE 2019. 97119.
+% [6] K. Liu, G. H. Paulino (2018). 'Highly efficient nonlinear
+%     structural analysis of origami assemblages using the MERLIN2
+%     software.' Origami^7.
+% [7] K. Liu, G. H. Paulino (2017). 'Nonlinear mechanics of non-rigid
+%     origami - An efficient computational approach.' Proc. R. Soc. A 473:
+%     20170348.
+% [8] K. Liu, G. H. Paulino (2016). 'MERLIN: A MATLAB implementation to
+%     capture highly nonlinear behavior of non-rigid origami.'
+%     Proceedings of IASS Annual Symposium 2016.
 %
 %%%%%%%%%%%%%%%%%%%%%%  Active Origami Simulator  %%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -41,7 +41,7 @@ ori=OrigamiSolver;
 
 %% Define the Geometry of origami
 % This section of code is used to generate the geometry of the origami
-% pattern before meshing; 
+% pattern before meshing;
 
 a=20*10^(-3);
 b=4*10^(-3);
@@ -52,44 +52,41 @@ ori.node0=[b 0 0;
       a+b 0 0;
       2*a+b 0 0;
       3*a+b 0 0;
-      4*a+b 0 0; 
+      4*a+b 0 0;
       5*a+b 0 0; %6
-      
       0 c 0;
       a c 0;
       2*a c 0;
       3*a+2*b c 0;
-      4*a+2*b c 0; 
+      4*a+2*b c 0;
       5*a+2*b c 0; %12
-      
-      b 2*c 0;
+      b c*2 0;
       a+b 2*c 0;
       2*a+b 2*c 0;
       3*a+b 2*c 0;
-      4*a+b 2*c 0; 
+      4*a+b 2*c 0;
       5*a+b 2*c 0; %18
-      
-      b 0 z;
+      b,0,z;
       -z+1*a+b 0 z;
       -z+2*a+b 0 z;
       z+3*a+b 0 z;
-      z+4*a+b 0 z; 
+      z+4*a+b 0 z;
       z+5*a+b 0 z; %6
-      
+
       0 c z;
       -z+1*a c z;
       -z+2*a c z;
       z+3*a+2*b c z;
-      z+4*a+2*b c z; 
+      z+4*a+2*b c z;
       z+5*a+2*b c z; %12
-      
-      b 2*c z;
+
+      b,2*c,z;
       -z+1*a+b 2*c z;
       -z+2*a+b 2*c z;
       z+3*a+b 2*c z;
       z+4*a+b 2*c z;
       z+5*a+b 2*c z;];
-  
+
 ori.panel0{1}=[1 2 8 7];
 ori.panel0{2}=[2 3 9 8];
 ori.panel0{3}=[3 4 10 9];
@@ -118,7 +115,7 @@ ori.Mesh_AnalyzeOriginalPattern();
 
 %% Meshing of the origami model
 
-% Define the crease width 
+% Define the crease width
 ori.creaseWidthVec=zeros(ori.oldCreaseNum,1);
 
 ori.creaseWidthVec(4)=3*10^(-3);
@@ -169,10 +166,10 @@ ori.Plot_MeshedOrigami(); % Plot the meshed origami for inspection;
 
 %% Assign Mechanical Properties
 
-ori.panelE=2*10^9; 
-ori.creaseE=2*10^9; 
+ori.panelE=2*10^9;
+ori.creaseE=2*10^9;
 ori.panelPoisson=0.3;
-ori.creasePoisson=0.3; 
+ori.creasePoisson=0.3;
 ori.panelThickVec=ones(20,1)*500*10^(-6);
 ori.panelW=3*10^-3;
 
@@ -268,7 +265,7 @@ selfFold.supp=[1,1,1,1;
 
 selfFold.increStep=30;
 selfFold.tol=10^-6;
-selfFold.iterMax=50;      
+selfFold.iterMax=50;
 
 
 
@@ -283,7 +280,7 @@ nr.supp=[2,1,1,1;
       20,1,1,0;
       23,1,1,0;
       35,1,1,0;];
-      
+
 nr.nonRigidSupport=1;
 ksup=5;
 nr.suppElastic=[19,3,ksup;
@@ -294,13 +291,13 @@ nr.suppElastic=[19,3,ksup;
              24,3,ksup;
              35,3,ksup;
              36,3,ksup;];
-      
+
 loadForce=5*10^(-3);
 nr.load=[21,0,0,loadForce;
       22,0,0,loadForce;
       33,0,0,loadForce;
-      34,0,0,loadForce;]; 
-     
+      34,0,0,loadForce;];
+
 nr.increStep=30;
 nr.tol=10^-6;
 nr.iterMax=50;


### PR DESCRIPTION
I changed this example because it would not work in octave. There were some funny things happening when parsing the node locations, and Octave doesn't support string comparisons of different lenghts using the `==` operator. If you would like to add this to your library the `strcmp` function also works in matlab.